### PR TITLE
Aligned with CubeSat Sim modifications to AO-7 format

### DIFF
--- a/cubesatsim.ksy
+++ b/cubesatsim.ksy
@@ -286,79 +286,79 @@ types:
         
     instances:
         channel_1a_val:
-          value: ((channel_1a_val_raw[0] - 0x30) * 10 + (channel_1a_val_raw[1] - 0x30)) * 29.5
-          doc: 'value * 29.5 [mA]'
+          value: ((channel_1a_val_raw[0] - 0x30) * 10 + (channel_1a_val_raw[1] - 0x30)) * 15
+          doc: 'value * 15 [mA]'
         channel_1b_val:
-          value: 1970 - (20 * ((channel_1b_val_raw[0] - 0x30) * 10 + (channel_1b_val_raw[1] - 0x30)))
-          doc: '1970 - (20 * value) [mA]'
+          value: 99 - (10 * ((channel_1b_val_raw[0] - 0x30) * 10 + (channel_1b_val_raw[1] - 0x30)))
+          doc: '99 - (10 * value) [mA]'
         channel_1c_val:
-          value: 1970 - (20 * ((channel_1c_val_raw[0] - 0x30) * 10 + (channel_1c_val_raw[1] - 0x30)))
-          doc: '1970 - (20 * value) [mA]'
+          value: 99 - (10 * ((channel_1c_val_raw[0] - 0x30) * 10 + (channel_1c_val_raw[1] - 0x30)))
+          doc: '99 - (10 * value) [mA]'
         channel_1d_val:
           value: (channel_1d_val_raw[0] - 0x30) * 10 + (channel_1d_val_raw[1] - 0x30)
-          doc: '1970 - (20 * value) [mA]'
+          doc: '99 - (10 * value) [mA]'
 
         channel_2a_val:
-          value: 1970 - (20 * ((channel_2a_val_raw[0] - 0x30) * 10 + (channel_2a_val_raw[1] - 0x30)))
-          doc: '1970 - (20 * value) [mA]'
+          value: 99 - (10 * ((channel_2a_val_raw[0] - 0x30) * 10 + (channel_2a_val_raw[1] - 0x30)))
+          doc: '99 - (10 * value) [mA]'
         channel_2b_val:
-          value: 8 * ((1 - 0.01 * ((channel_2b_val_raw[0] - 0x30) * 10 + (channel_2b_val_raw[1] - 0x30))) * (1 - 0.01 * ((channel_2b_val_raw[0] - 0x30) * 10 + (channel_2b_val_raw[1] - 0x30))))
-          doc: '8 * (1 - 0.01 * value)^2 [W]'
+          value: 99 - (10 * ((channel_2b_val_raw[0] - 0x30) * 10 + (channel_2b_val_raw[1] - 0x30)))
+          doc: '99 - (10 * value) [mA]'
         channel_2c_val:
-          value: 15.16 * ((channel_2c_val_raw[0] - 0x30) * 10 + (channel_2c_val_raw[1] - 0x30))
-          doc: '15.16 * value [h]'
+          value: 99 - (10 * ((channel_2c_val_raw[0] - 0x30) * 10 + (channel_2c_val_raw[1] - 0x30)))
+          doc: '99 - (10 * value) [mA]'
         channel_2d_val:
-          value: 40 * (((channel_2d_val_raw[0] - 0x30) * 10 + (channel_2d_val_raw[1] - 0x30)) - 50)
-          doc: '40 * (value - 50) [mA]'
+          value: 10 * (((channel_2d_val_raw[0] - 0x30) * 10 + (channel_2d_val_raw[1] - 0x30)) - 50)
+          doc: '10 * (value - 50) [mA]'
 
         channel_3a_val:
-          value: 0.1 * ((channel_3a_val_raw[0] - 0x30) * 10 + (channel_3a_val_raw[1] - 0x30)) + 6.4
-          doc: '0.1 * value + 6.4 [V]'
+          value: 0.1 * ((channel_3a_val_raw[0] - 0x30) * 10 + (channel_3a_val_raw[1] - 0x30)) + 6.5
+          doc: '0.1 * (value + 6.5) [V]'
         channel_3b_val:
           value: 0.1 * ((channel_3b_val_raw[0] - 0x30) * 10 + (channel_3b_val_raw[1] - 0x30))
           doc: '0.1 * value [V]'
         channel_3c_val:
           value: 0.15 * ((channel_3c_val_raw[0] - 0x30) * 10 + (channel_3c_val_raw[1] - 0x30))
-          doc: '0.15 * value [V]'
+          doc: 'Note Used: 0.15 * value [V]'
         channel_3d_val:
           value: 95.8 - 1.48 * ((channel_3d_val_raw[0] - 0x30) * 10 + (channel_3d_val_raw[1] - 0x30))
-          doc: '95.8 - 1.48 * value [°C]'
+          doc: 'Not Used: 95.8 - 1.48 * value [°C]'
 
         channel_4a_val:
           value: 95.8 - 1.48 * ((channel_4a_val_raw[0] - 0x30) * 10 + (channel_4a_val_raw[1] - 0x30))
           doc: '95.8 - 1.48 * value [°C]'
         channel_4b_val:
           value: 95.8 - 1.48 * ((channel_4b_val_raw[0] - 0x30) * 10 + (channel_4b_val_raw[1] - 0x30))
-          doc: '95.8 - 1.48 * value [°C]'
+          doc: 'Note Used: 95.8 - 1.48 * value [°C]'
         channel_4c_val:
           value: 95.8 - 1.48 * ((channel_4c_val_raw[0] - 0x30) * 10 + (channel_4c_val_raw[1] - 0x30))
-          doc: '95.8 - 1.48 * value [°C]'
+          doc: 'Not Used: 95.8 - 1.48 * value [°C]'
         channel_4d_val:
           value: 95.8 - 1.48 * ((channel_4d_val_raw[0] - 0x30) * 10 + (channel_4d_val_raw[1] - 0x30))
-          doc: '95.8 - 1.48 * value [°C]'
+          doc: 'Not Used: 95.8 - 1.48 * value [°C]'
   
         channel_5a_val:
           value: 95.8 - 1.48 * ((channel_5a_val_raw[0] - 0x30) * 10 + (channel_5a_val_raw[1] - 0x30))
-          doc: '95.8 - 1.48 * value [°C]'
+          doc: 'Not Used: 95.8 - 1.48 * value [°C]'
         channel_5b_val:
           value: 11.67 * ((channel_5b_val_raw[0] - 0x30) * 10 + (channel_5b_val_raw[1] - 0x30))
-          doc: '11.67 * value [mA]'
+          doc: 'Not Used: 11.67 * value [mA]'
         channel_5c_val:
           value: 95.8 - 1.48 * ((channel_5c_val_raw[0] - 0x30) * 10 + (channel_5c_val_raw[1] - 0x30))
-          doc: '95.8 - 1.48 * value [°C]'
+          doc: 'Not Used: 95.8 - 1.48 * value [°C]'
         channel_5d_val:
           value: 11 + 0.82 * ((channel_5d_val_raw[0] - 0x30) * 10 + (channel_5d_val_raw[1] - 0x30))
-          doc: '11 + 0.82 * value [mA]'
+          doc: 'Not Used: 11 + 0.82 * value [mA]'
 
         channel_6a_val:
           value: (((channel_6a_val_raw[0] - 0x30) * 10 + (channel_6a_val_raw[1] - 0x30)) * ((channel_6a_val_raw[0] - 0x30) * 10 + (channel_6a_val_raw[1] - 0x30))) / 1.56
-          doc: 'value^2 / 1.56 [mA]'
+          doc: 'Not Used: value^2 / 1.56 [mA]'
         channel_6b_val:
           value: 0.1 * (((channel_6b_val_raw[0] - 0x30) * 10 + (channel_6b_val_raw[1] - 0x30)) * ((channel_6b_val_raw[0] - 0x30) * 10 + (channel_6b_val_raw[1] - 0x30))) + 35
-          doc: '0.1 * value^2 + 35 [mA]'
+          doc: 'Not Used: 0.1 * value^2 + 35 [mA]'
         channel_6c_val:
           value: 0.041 * (((channel_6c_val_raw[0] - 0x30) * 10 + (channel_6c_val_raw[1] - 0x30)) * ((channel_6c_val_raw[0] - 0x30) * 10 + (channel_6c_val_raw[1] - 0x30)))
-          doc: '0.041 * value^2 [mA]'
+          doc: 'Not Used: 0.041 * value^2 [mA]'
         channel_6d_val:
           value: 0.01 * ((channel_6d_val_raw[0] - 0x30) * 10 + (channel_6d_val_raw[1] - 0x30))
           doc: '0.01 * value'


### PR DESCRIPTION
I didn't know what to do with the channels that I don't use, so I just marked them "Not Used".  I just send 00 for each.

I didn't know where the labels were - how to I identify channel 1B as the +X Panel Current, for example?